### PR TITLE
Correct name spelling in `about.mdx`

### DIFF
--- a/apps/docs/content/getting-started/about.mdx
+++ b/apps/docs/content/getting-started/about.mdx
@@ -30,7 +30,7 @@ hard work so I'd like to recognize and thank them:
   Components has made it easier than ever to build UI that is
   functional and accessible to all users.
 
-  I'd especially like to acknowledge [@devongarret](https://twitter.com/devongovett)
+  I'd especially like to acknowledge [@devongovett](https://twitter.com/devongovett)
   who has been representing React Aria on Twitter and has been very
   communicative about the team's progress and quick to respond
   to feedback.


### PR DESCRIPTION
Reading the docs I noticed that while the link worked, Devon Govett was misspelled as Devon Garrett. Figured I'd make a quick PR to fix that.