### PR TITLE
fix: Fix site navigation focus state

### DIFF
--- a/apps/docs/app/changelog/layout.tsx
+++ b/apps/docs/app/changelog/layout.tsx
@@ -48,7 +48,7 @@ export default async function DocsLayout({
       <Navigation componentList={sortedComponents} />
       <aside className="fixed top-0 hidden h-full shrink-0 border-r pt-14 dark:border-slate-800 md:w-56 lg:block">
         <nav
-          className="h-full overflow-y-auto py-10"
+          className="-ml-3 h-full overflow-y-auto py-10 pl-3"
           id="site-navigation"
           tabIndex={-1}
         >

--- a/apps/docs/app/changelog/page.tsx
+++ b/apps/docs/app/changelog/page.tsx
@@ -54,10 +54,10 @@ export default async function ChangelogPage() {
 
   return (
     <>
-      <div className="order-2 hidden shrink-0 pl-4 md:pl-8 lg:w-1/4 xl:block">
+      <div className="order-2 hidden shrink-0 lg:w-1/4 xl:block">
         <div className="fixed top-0 h-screen pt-16">
           <div className="h-full overflow-y-auto">
-            <div className="my-12 pr-4">
+            <div className="my-12 px-4 md:pl-8">
               <PageToc headings={post.toc} />
             </div>
           </div>

--- a/apps/docs/app/docs/[[...slug]]/layout.tsx
+++ b/apps/docs/app/docs/[[...slug]]/layout.tsx
@@ -51,7 +51,7 @@ export default async function DocsLayout({
       <Navigation componentList={sortedComponents} />
       <aside className="fixed top-0 hidden h-full shrink-0 border-r pt-14 dark:border-slate-800 md:w-56 lg:block">
         <nav
-          className="h-full overflow-y-auto py-10"
+          className="-ml-3 h-full overflow-y-auto py-10 pl-3"
           id="site-navigation"
           tabIndex={-1}
         >

--- a/apps/docs/app/docs/[[...slug]]/page.tsx
+++ b/apps/docs/app/docs/[[...slug]]/page.tsx
@@ -68,10 +68,10 @@ export default async function DocPage({
 
   return (
     <>
-      <div className="order-2 hidden shrink-0 pl-4 md:pl-8 lg:w-1/4 xl:block">
+      <div className="order-2 hidden shrink-0 lg:w-1/4 xl:block">
         <div className="fixed top-0 h-screen pt-16">
           <div className="h-full overflow-y-auto">
-            <div className="my-12 pr-4">
+            <div className="my-12 px-4 md:pl-8">
               <PageToc headings={post.toc} />
             </div>
           </div>

--- a/apps/docs/app/getting-started/[[...slug]]/layout.tsx
+++ b/apps/docs/app/getting-started/[[...slug]]/layout.tsx
@@ -55,7 +55,7 @@ export default async function DocsLayout({
       <Navigation componentList={sortedComponents} />
       <aside className="fixed top-0 hidden h-full shrink-0 border-r pt-14 dark:border-slate-800 md:w-56 lg:block">
         <nav
-          className="h-full overflow-y-auto py-10"
+          className="-ml-3 h-full overflow-y-auto py-10 pl-3"
           id="site-navigation"
           tabIndex={-1}
         >

--- a/apps/docs/app/getting-started/[[...slug]]/page.tsx
+++ b/apps/docs/app/getting-started/[[...slug]]/page.tsx
@@ -75,7 +75,7 @@ export default async function GettingStartedPage({
       <div className="order-2 hidden shrink-0 lg:w-1/4 xl:block">
         <div className="fixed top-0 h-screen pt-16">
           <div className="h-full overflow-y-auto">
-            <div className="px-4 md:pl-8">
+            <div className="my-12 px-4 md:pl-8">
               {post.toc.length > 0 ? <PageToc headings={post.toc} /> : null}
             </div>
           </div>

--- a/apps/docs/app/getting-started/[[...slug]]/page.tsx
+++ b/apps/docs/app/getting-started/[[...slug]]/page.tsx
@@ -72,10 +72,10 @@ export default async function GettingStartedPage({
 
   return (
     <>
-      <div className="order-2 hidden shrink-0 pl-4 md:pl-8 lg:w-1/4 xl:block">
+      <div className="order-2 hidden shrink-0 lg:w-1/4 xl:block">
         <div className="fixed top-0 h-screen pt-16">
           <div className="h-full overflow-y-auto">
-            <div className="my-12 pr-4">
+            <div className="px-4 md:pl-8">
               {post.toc.length > 0 ? <PageToc headings={post.toc} /> : null}
             </div>
           </div>


### PR DESCRIPTION
Fixes: #16 

### Before
![CleanShot 2023-12-31 at 14 12 25](https://github.com/IHIutch/draft-ui/assets/26093912/a5921e07-e0c6-42c1-a34a-40253bd7612b)
* The sidebar navigation and the `on this page` table of contents have focus states that are getting cut off.

### After
![CleanShot 2023-12-31 at 14 08 55](https://github.com/IHIutch/draft-ui/assets/26093912/115df3e1-f3ad-404a-9ddb-08f54f14f189)
* Add padding/margin to avoid focus states from getting cut off (this fixes /getting-started, /changelog, and /components.
