### PR TITLE
fix: Broken aria-labels

### DIFF
--- a/apps/docs/components/docs/component-example.tsx
+++ b/apps/docs/components/docs/component-example.tsx
@@ -55,7 +55,7 @@ export default function ComponentExample({
   return (
     <div>
       <Tabs>
-        <TabList aria-label="History of Ancient Rome">
+        <TabList aria-label="Preview and Code Tabs">
           <Tab id="example">Example</Tab>
           <Tab id="code">Code</Tab>
         </TabList>


### PR DESCRIPTION
Noticed the aria-labels were still copied from the react-aria examples. Happy to change to something else more fitting if we think this isn't descriptive enough.