### PR TITLE
Update Breadcrumb API 

### DIFF
--- a/apps/docs/content/components/breadcrumbs.mdx
+++ b/apps/docs/content/components/breadcrumbs.mdx
@@ -12,6 +12,13 @@ To install, copy the code below and paste into your project.
 
 ## Examples
 
+<Callout type="important">
+    By default, links perform native browser navigation when they are interacted with.
+    However, many apps and frameworks use client side routers to avoid a full page reload when navigating between pages.
+    React Aria components provide a `<RouterProvider>` so you can hook into your routing framework of choice.
+    Read more about it in the <a className="underline" href="https://react-spectrum.adobe.com/react-aria/routing.html" target="__blank">Client side Routing</a> section.
+</Callout>
+
 ### Default
 
 This is an example of the default Breadcrumb component

--- a/apps/docs/registry/breadcrumbs/default.tsx
+++ b/apps/docs/registry/breadcrumbs/default.tsx
@@ -1,14 +1,14 @@
 import { ChevronRight } from 'lucide-react'
-import { BreadcrumbItem, Breadcrumbs } from 'ui'
+import { BreadcrumbItem, BreadcrumbLink, Breadcrumbs } from 'ui'
 
 export default function Default() {
   return (
     <Breadcrumbs>
       <BreadcrumbItem separator={<ChevronRight size="1em" />}>
-        <a href="#">Home</a>
+        <BreadcrumbLink href="#">Home</BreadcrumbLink>
       </BreadcrumbItem>
       <BreadcrumbItem separator={<ChevronRight size="1em" />}>
-        <a href="#">React Aria</a>
+        <BreadcrumbLink href="#">React Aria</BreadcrumbLink>
       </BreadcrumbItem>
       <BreadcrumbItem>useBreadcrumbs</BreadcrumbItem>
     </Breadcrumbs>

--- a/apps/storybook/src/components/breadcrumbs/stories/default.tsx
+++ b/apps/storybook/src/components/breadcrumbs/stories/default.tsx
@@ -1,14 +1,14 @@
 import { ChevronRight } from 'lucide-react'
-import { BreadcrumbItem, Breadcrumbs } from 'ui'
+import { BreadcrumbItem, BreadcrumbLink, Breadcrumbs } from 'ui'
 
 export default function Default() {
   return (
     <Breadcrumbs>
       <BreadcrumbItem separator={<ChevronRight size="1em" />}>
-        <a href="#">Home</a>
+        <BreadcrumbLink href="#">Home</BreadcrumbLink>
       </BreadcrumbItem>
       <BreadcrumbItem separator={<ChevronRight size="1em" />}>
-        <a href="#">React Aria</a>
+        <BreadcrumbLink href="#">React Aria</BreadcrumbLink>
       </BreadcrumbItem>
       <BreadcrumbItem>useBreadcrumbs</BreadcrumbItem>
     </Breadcrumbs>

--- a/packages/ui/src/breadcrumbs.tsx
+++ b/packages/ui/src/breadcrumbs.tsx
@@ -43,10 +43,13 @@ const _BreadcrumbItem = ({
   )
 }
 
-const _BreadcrumbLink = ({ children, ...props }: LinkProps) => {
+const _BreadcrumbLink = ({ children, className, ...props }: LinkProps) => {
   return (
     <Link
-      className="text-slate-500 hover:underline current:text-black current:hover:no-underline dark:text-slate-300 dark:current:text-white"
+      className={cx(
+        'text-slate-500 hover:underline current:text-black current:hover:no-underline dark:text-slate-300 dark:current:text-white',
+        className,
+      )}
       {...props}
     >
       {children}

--- a/packages/ui/src/breadcrumbs.tsx
+++ b/packages/ui/src/breadcrumbs.tsx
@@ -8,6 +8,7 @@ import {
   Link,
   type BreadcrumbProps,
   type BreadcrumbsProps,
+  type LinkProps,
 } from 'react-aria-components'
 
 import { cx } from '@/lib/cva.config'
@@ -32,9 +33,7 @@ const _BreadcrumbItem = ({
 }: _BreadcrumbItemProps) => {
   return (
     <Breadcrumb className="flex items-center gap-1" {...props}>
-      <Link className="text-slate-500 hover:underline current:text-black current:hover:no-underline dark:text-slate-300 dark:current:text-white">
-        {children}
-      </Link>
+      {children}
       {separator ? (
         <div aria-hidden="true" className="text-slate-400 dark:text-slate-500">
           {separator}
@@ -44,4 +43,19 @@ const _BreadcrumbItem = ({
   )
 }
 
-export { _Breadcrumbs as Breadcrumbs, _BreadcrumbItem as BreadcrumbItem }
+const _BreadcrumbLink = ({ children, ...props }: LinkProps) => {
+  return (
+    <Link
+      className="text-slate-500 hover:underline current:text-black current:hover:no-underline dark:text-slate-300 dark:current:text-white"
+      {...props}
+    >
+      {children}
+    </Link>
+  )
+}
+
+export {
+  _Breadcrumbs as Breadcrumbs,
+  _BreadcrumbItem as BreadcrumbItem,
+  _BreadcrumbLink as BreadcrumbLink,
+}


### PR DESCRIPTION
## Overview
Fixes #19 by exposing `BreadcrumbLink` since React aria's `Link` component no longer clones children.

## Example
![CleanShot 2024-01-06 at 13 17 26](https://github.com/IHIutch/draft-ui/assets/26093912/2dbe4d38-f98a-42e8-a1e4-295f42c70786)
* There's no longer duplicate anchor elements.

## Docs
![CleanShot 2024-01-06 at 13 17 05@2x](https://github.com/IHIutch/draft-ui/assets/26093912/c802dae8-42ff-4e44-9780-7b6dddac1faf)
* I tried to keep the docs light and just point to the React aria component docs instead. I wasn't sure where the best place to put this was but I tried to also follow other conventions I saw used on different components like `Input`