### PR TITLE
Add links for feedback + editing docs

### DIFF
--- a/apps/docs/app/docs/[[...slug]]/page.tsx
+++ b/apps/docs/app/docs/[[...slug]]/page.tsx
@@ -3,6 +3,7 @@ import { type Metadata, type ResolvingMetadata } from 'next'
 import { notFound } from 'next/navigation'
 
 import Markdown from '@/components/docs/markdown'
+import EditFeedbackLinks from '@/components/edit-feedback'
 import PageToc from '@/components/page-toc'
 
 export async function generateStaticParams() {
@@ -73,6 +74,8 @@ export default async function DocPage({
           <div className="h-full overflow-y-auto">
             <div className="my-12 px-4 md:pl-8">
               <PageToc headings={post.toc} />
+              {/* TODO: Fix the spacing on this to separate it from the TOC above */}
+              <EditFeedbackLinks post={post} />
             </div>
           </div>
         </div>

--- a/apps/docs/app/docs/[[...slug]]/page.tsx
+++ b/apps/docs/app/docs/[[...slug]]/page.tsx
@@ -74,7 +74,6 @@ export default async function DocPage({
           <div className="h-full overflow-y-auto">
             <div className="my-12 px-4 md:pl-8">
               <PageToc headings={post.toc} />
-              {/* TODO: Fix the spacing on this to separate it from the TOC above */}
               <EditFeedbackLinks post={post} />
             </div>
           </div>

--- a/apps/docs/app/docs/[[...slug]]/page.tsx
+++ b/apps/docs/app/docs/[[...slug]]/page.tsx
@@ -74,7 +74,10 @@ export default async function DocPage({
           <div className="h-full overflow-y-auto">
             <div className="my-12 px-4 md:pl-8">
               <PageToc headings={post.toc} />
-              <EditFeedbackLinks post={post} />
+              <EditFeedbackLinks
+                post={post}
+                contentPath={post._raw.sourceFilePath}
+              />
             </div>
           </div>
         </div>

--- a/apps/docs/app/getting-started/[[...slug]]/page.tsx
+++ b/apps/docs/app/getting-started/[[...slug]]/page.tsx
@@ -70,7 +70,6 @@ export default async function GettingStartedPage({
   if (!post) {
     notFound()
   }
-  post._raw.sourceFilePath
   return (
     <>
       <div className="order-2 hidden shrink-0 lg:w-1/4 xl:block">
@@ -80,7 +79,7 @@ export default async function GettingStartedPage({
               {post.toc.length > 0 ? <PageToc headings={post.toc} /> : null}
               <EditFeedbackLinks
                 contentPath={post._raw.sourceFilePath}
-                post={post}
+                title={post.title}
               />
             </div>
           </div>

--- a/apps/docs/app/getting-started/[[...slug]]/page.tsx
+++ b/apps/docs/app/getting-started/[[...slug]]/page.tsx
@@ -70,7 +70,7 @@ export default async function GettingStartedPage({
   if (!post) {
     notFound()
   }
-
+  post._raw.sourceFilePath
   return (
     <>
       <div className="order-2 hidden shrink-0 lg:w-1/4 xl:block">
@@ -78,7 +78,10 @@ export default async function GettingStartedPage({
           <div className="h-full overflow-y-auto">
             <div className="my-12 px-4 md:pl-8">
               {post.toc.length > 0 ? <PageToc headings={post.toc} /> : null}
-              <EditFeedbackLinks post={post} />
+              <EditFeedbackLinks
+                contentPath={post._raw.sourceFilePath}
+                post={post}
+              />
             </div>
           </div>
         </div>

--- a/apps/docs/app/getting-started/[[...slug]]/page.tsx
+++ b/apps/docs/app/getting-started/[[...slug]]/page.tsx
@@ -5,6 +5,7 @@ import { type Metadata, type ResolvingMetadata } from 'next'
 import { notFound } from 'next/navigation'
 
 import Markdown from '@/components/docs/markdown'
+import EditFeedbackLinks from '@/components/edit-feedback'
 import PageToc from '@/components/page-toc'
 
 export async function generateStaticParams() {
@@ -77,6 +78,7 @@ export default async function GettingStartedPage({
           <div className="h-full overflow-y-auto">
             <div className="my-12 px-4 md:pl-8">
               {post.toc.length > 0 ? <PageToc headings={post.toc} /> : null}
+              <EditFeedbackLinks post={post} />
             </div>
           </div>
         </div>

--- a/apps/docs/components/edit-feedback.tsx
+++ b/apps/docs/components/edit-feedback.tsx
@@ -17,9 +17,9 @@ export default function EditFeedbackLinks({ post }: Props) {
   pageFeedbackUrl.searchParams.set('labels', 'documentation')
 
   return (
-    <span className="flex flex-col space-y-2">
+    <span className="flex flex-col space-y-2 pt-6">
       <a
-        className="mt-6 text-xs text-slate-600 hover:text-slate-900 dark:text-slate-400 dark:hover:text-white"
+        className="text-xs text-slate-600 hover:text-slate-900 dark:text-slate-400 dark:hover:text-white"
         href={pageEditUrl}
       >
         Edit this page

--- a/apps/docs/components/edit-feedback.tsx
+++ b/apps/docs/components/edit-feedback.tsx
@@ -14,23 +14,25 @@ export default function EditFeedbackLinks({ title, contentPath }: Props) {
 
   return (
     <ul className="mt-3">
-      <li className="py-1">
-        <a
-          className="text-xs text-slate-600 hover:text-slate-900 dark:text-slate-400 dark:hover:text-white"
-          href={pageEditUrl}
-        >
-          Edit this page
-        </a>
-      </li>
-      <li className="py-1">
-        <a
-          className="text-xs text-slate-600 hover:text-slate-900 dark:text-slate-400 dark:hover:text-white"
-          href={pageFeedbackUrl.toString()}
-          target="_blank"
-        >
-          Give us feedback
-        </a>
-      </li>
+      <LinkItem href={pageEditUrl}>Edit this page</LinkItem>
+      <LinkItem href={pageFeedbackUrl.toString()}>Give us feedback</LinkItem>
     </ul>
   )
 }
+
+const LinkItem = ({
+  href,
+  children,
+}: {
+  href: string
+  children?: React.ReactNode
+}) => (
+  <li className="">
+    <a
+      className={`block rounded-sm py-1 text-sm text-slate-600 no-underline transition hover:text-slate-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 focus-visible:ring-offset-2 dark:text-slate-400 dark:hover:text-white dark:focus-visible:ring-slate-400 dark:focus-visible:ring-offset-slate-900`}
+      href={href}
+    >
+      {children}
+    </a>
+  </li>
+)

--- a/apps/docs/components/edit-feedback.tsx
+++ b/apps/docs/components/edit-feedback.tsx
@@ -1,0 +1,36 @@
+type MinimalPost = {
+  title: string
+  slug: string
+}
+
+type Props = {
+  post: MinimalPost
+}
+
+export default function EditFeedbackLinks({ post }: Props) {
+  const pageEditUrl = `https://github.com/IHIutch/draft-ui/tree/main/apps${post.slug}`
+  const pageFeedbackUrl = new URL(
+    `https://github.com/IHIutch/draft-ui/issues/new`,
+  )
+  pageFeedbackUrl.searchParams.set('title', `Feedback for “${post.title}”`)
+  // Is this the right label to set? Do we need to make a new label for this?
+  pageFeedbackUrl.searchParams.set('labels', 'documentation')
+
+  return (
+    <span className="flex flex-col space-y-2">
+      <a
+        className="mt-6 text-xs text-slate-600 hover:text-slate-900 dark:text-slate-400 dark:hover:text-white"
+        href={pageEditUrl}
+      >
+        Edit this page
+      </a>
+      <a
+        className="mt-6 text-xs text-slate-600 hover:text-slate-900 dark:text-slate-400 dark:hover:text-white"
+        href={pageFeedbackUrl.toString()}
+        target="_blank"
+      >
+        Give us feedback
+      </a>
+    </span>
+  )
+}

--- a/apps/docs/components/edit-feedback.tsx
+++ b/apps/docs/components/edit-feedback.tsx
@@ -5,10 +5,11 @@ type MinimalPost = {
 
 type Props = {
   post: MinimalPost
+  contentPath: string
 }
 
-export default function EditFeedbackLinks({ post }: Props) {
-  const pageEditUrl = `https://github.com/IHIutch/draft-ui/tree/main/apps${post.slug}`
+export default function EditFeedbackLinks({ post, contentPath }: Props) {
+  const pageEditUrl = `https://github.com/IHIutch/draft-ui/tree/main/apps/docs/content/${contentPath}`
   const pageFeedbackUrl = new URL(
     `https://github.com/IHIutch/draft-ui/issues/new`,
   )

--- a/apps/docs/components/edit-feedback.tsx
+++ b/apps/docs/components/edit-feedback.tsx
@@ -13,20 +13,24 @@ export default function EditFeedbackLinks({ title, contentPath }: Props) {
   pageFeedbackUrl.searchParams.set('labels', 'documentation')
 
   return (
-    <span className="flex flex-col space-y-2 pt-6">
-      <a
-        className="text-xs text-slate-600 hover:text-slate-900 dark:text-slate-400 dark:hover:text-white"
-        href={pageEditUrl}
-      >
-        Edit this page
-      </a>
-      <a
-        className="mt-6 text-xs text-slate-600 hover:text-slate-900 dark:text-slate-400 dark:hover:text-white"
-        href={pageFeedbackUrl.toString()}
-        target="_blank"
-      >
-        Give us feedback
-      </a>
-    </span>
+    <ul className="mt-3">
+      <li className="py-1">
+        <a
+          className="text-xs text-slate-600 hover:text-slate-900 dark:text-slate-400 dark:hover:text-white"
+          href={pageEditUrl}
+        >
+          Edit this page
+        </a>
+      </li>
+      <li className="py-1">
+        <a
+          className="text-xs text-slate-600 hover:text-slate-900 dark:text-slate-400 dark:hover:text-white"
+          href={pageFeedbackUrl.toString()}
+          target="_blank"
+        >
+          Give us feedback
+        </a>
+      </li>
+    </ul>
   )
 }

--- a/apps/docs/components/edit-feedback.tsx
+++ b/apps/docs/components/edit-feedback.tsx
@@ -1,9 +1,10 @@
-type Props = {
+export default function EditFeedbackLinks({
+  title,
+  contentPath,
+}: {
   title: string
   contentPath: string
-}
-
-export default function EditFeedbackLinks({ title, contentPath }: Props) {
+}) {
   const pageEditUrl = `https://github.com/IHIutch/draft-ui/tree/main/apps/docs/content/${contentPath}`
   const pageFeedbackUrl = new URL(
     `https://github.com/IHIutch/draft-ui/issues/new`,
@@ -29,7 +30,7 @@ const LinkItem = ({
 }) => (
   <li>
     <a
-      className={`block rounded-sm py-1 text-sm text-slate-600 no-underline transition hover:text-slate-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 focus-visible:ring-offset-2 dark:text-slate-400 dark:hover:text-white dark:focus-visible:ring-slate-400 dark:focus-visible:ring-offset-slate-900`}
+      className="block rounded-sm py-1 text-sm text-slate-600 no-underline transition hover:text-slate-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 focus-visible:ring-offset-2 dark:text-slate-400 dark:hover:text-white dark:focus-visible:ring-slate-400 dark:focus-visible:ring-offset-slate-900"
       href={href}
     >
       {children}

--- a/apps/docs/components/edit-feedback.tsx
+++ b/apps/docs/components/edit-feedback.tsx
@@ -1,19 +1,14 @@
-type MinimalPost = {
-  title: string
-  slug: string
-}
-
 type Props = {
-  post: MinimalPost
+  title: string
   contentPath: string
 }
 
-export default function EditFeedbackLinks({ post, contentPath }: Props) {
+export default function EditFeedbackLinks({ title, contentPath }: Props) {
   const pageEditUrl = `https://github.com/IHIutch/draft-ui/tree/main/apps/docs/content/${contentPath}`
   const pageFeedbackUrl = new URL(
     `https://github.com/IHIutch/draft-ui/issues/new`,
   )
-  pageFeedbackUrl.searchParams.set('title', `Feedback for “${post.title}”`)
+  pageFeedbackUrl.searchParams.set('title', `Feedback for “${title}”`)
   // Is this the right label to set? Do we need to make a new label for this?
   pageFeedbackUrl.searchParams.set('labels', 'documentation')
 

--- a/apps/docs/components/edit-feedback.tsx
+++ b/apps/docs/components/edit-feedback.tsx
@@ -27,7 +27,7 @@ const LinkItem = ({
   href: string
   children?: React.ReactNode
 }) => (
-  <li className="">
+  <li>
     <a
       className={`block rounded-sm py-1 text-sm text-slate-600 no-underline transition hover:text-slate-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 focus-visible:ring-offset-2 dark:text-slate-400 dark:hover:text-white dark:focus-visible:ring-slate-400 dark:focus-visible:ring-offset-slate-900`}
       href={href}


### PR DESCRIPTION
Addresses #12  
Please let me know if the style isn't consistent with the rest of the docs - I did my best there lol. Also - since the edit + feedback links are in the same container as the ToC, they disappear when the page shrinks. Let me know if this is a problem.